### PR TITLE
rename .md links to .html in markdown source

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ sudo npm install -g
 
 ## Usage
 
-### Generate static website (`--mode=convert`)
+### Generate static website
 
 ```bash
 markdown-to-html -O output sample
 ```
 
-### Serve markdown file (`--mode=serve`)
+### Serve markdown file
 
 ```bash
 markdown-serve --mode serve sample

--- a/demo/01-default-layout/demo/index.html
+++ b/demo/01-default-layout/demo/index.html
@@ -17,6 +17,9 @@
       margin: auto;
       padding-bottom: 50px;
     }
+    @media print {
+      .pagebreak { page-break-before: always; }
+    }
   </style>
 </head>
 

--- a/demo/01-default-layout/index.html
+++ b/demo/01-default-layout/index.html
@@ -17,6 +17,9 @@
       margin: auto;
       padding-bottom: 50px;
     }
+    @media print {
+      .pagebreak { page-break-before: always; }
+    }
   </style>
 </head>
 
@@ -24,8 +27,7 @@
   <article class="markdown-body">
     <h1 id="sample-markdown-file"><a href="#sample-markdown-file" class="anchor"></a>Sample markdown file</h1><p>This file provides a sample content for the default layout.</p>
 <h2 id="table-of-content"><a href="#table-of-content" class="anchor"></a>Table of content</h2><ul>
-<li><a href="#table-of-content">Table of content</a></li>
-<li><a href="#basic-features">Basic features</a><ul>
+<li><a href="#table-of-content">Table of content</a><ul>
 <li><a href="#html-views">HTML views</a></li>
 <li><a href="#links">Links</a></li>
 </ul>
@@ -37,7 +39,7 @@
 </ul>
 </li>
 </ul>
-<h2 id="basic-features"><a href="#basic-features" class="anchor"></a>Basic features</h2><h3 id="html-views"><a href="#html-views" class="anchor"></a>HTML views</h3><p>The content of <a href="demo/index.html">demo/index.html</a> is included in the layout so that it is possible to mix markdown and lightweight HTML/JS samples.</p>
+<h3 id="html-views"><a href="#html-views" class="anchor"></a>HTML views</h3><p>The content of <a href="demo/index.html">demo/index.html</a> is included in the layout so that it is possible to mix markdown and lightweight HTML/JS samples.</p>
 <h3 id="links"><a href="#links" class="anchor"></a>Links</h3><ul>
 <li><p>Internal markdown links with relative path</p>
 <ul>

--- a/demo/01-default-layout/other-file.html
+++ b/demo/01-default-layout/other-file.html
@@ -17,6 +17,9 @@
       margin: auto;
       padding-bottom: 50px;
     }
+    @media print {
+      .pagebreak { page-break-before: always; }
+    }
   </style>
 </head>
 

--- a/demo/02-remarkjs/another.html
+++ b/demo/02-remarkjs/another.html
@@ -2,34 +2,25 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>index.md</title>
+    <title>another.md</title>
     <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
     <textarea id="source">
-    # RemarkJS layout
+    # Another slideshow
 
 ---
 
-# Slide 1
+# Another slideshow
 
-This is the first slide
-
----
-
-
-# Slide 2
-
-This is the second slide.
-
-Details in [another](another.html) slideshow.
+This should be correctly linked.
 
 ---
 
 
-# Slide 3
+# The end
 
-See [https://remarkjs.com](https://remarkjs.com) for more features.
+[Back to index](index.html)
 
 
     </textarea>

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "start": "markdown-to-html -m serve -l default test/data",
     "build-demo": "npm run build-demo-01 && npm run build-demo-02",
-    "build-demo-01": "rm -rf demo/01-default-layout && markdown-to-html -m convert -l default -O demo/01-default-layout samples/01-default-layout",
-    "build-demo-02": "rm -rf demo/02-remarkjs && markdown-to-html -m convert -l remarkjs -O demo/02-remarkjs samples/02-remarkjs",
+    "build-demo-01": "rm -rf demo/01-default-layout && node bin/markdown-to-html.js -m convert -l default -O demo/01-default-layout samples/01-default-layout",
+    "build-demo-02": "rm -rf demo/02-remarkjs && node bin/markdown-to-html.js -m convert -l remarkjs -O demo/02-remarkjs samples/02-remarkjs",
     "test": "npm run check-style && nyc --reporter=html --reporter=text --reporter=cobertura mocha",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "check-style": "prettier --check \"src/**/*.js\" \"test/**/*.js\" \"bin/*.js\"",

--- a/samples/02-remarkjs/another.md
+++ b/samples/02-remarkjs/another.md
@@ -1,0 +1,15 @@
+# Another slideshow
+
+---
+
+# Another slideshow
+
+This should be correctly linked.
+
+---
+
+
+# The end
+
+[Back to index](index.md)
+

--- a/samples/02-remarkjs/index.md
+++ b/samples/02-remarkjs/index.md
@@ -11,7 +11,9 @@ This is the first slide
 
 # Slide 2
 
-This is the second slide
+This is the second slide.
+
+Details in [another](another.md) slideshow.
 
 ---
 

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -14,6 +14,7 @@ const handlebars = require('handlebars');
 handlebars.registerHelper('asset', require('./handlebars/asset'));
 
 const MarkdownRenderer = require('./marked/MarkdownRenderer');
+const rewriteLinksToHtml = require('./helpers/rewriteLinksToHtml');
 
 /**
  * Helper class to render markdown files in a directory
@@ -29,10 +30,9 @@ class Renderer {
     constructor(sourceDir, layout, options) {
         this.sourceDir = sourceDir;
         this.layout = layout;
+        this.renameMarkdownLinksToHtml = options.mode == RendererMode.CONVERT;
 
-        this.markdownRenderer = new MarkdownRenderer({
-            renameMarkdownLinksToHtml: options.mode == RendererMode.CONVERT,
-        });
+        this.markdownRenderer = new MarkdownRenderer();
     }
 
     /**
@@ -46,6 +46,10 @@ class Renderer {
         let markdownContent = null;
         if (FileType.MARKDOWN == sourceFile.type) {
             markdownContent = fs.readFileSync(sourceFile.absolutePath, 'utf8');
+            // replace .md links by .html links
+            if (this.renameMarkdownLinksToHtml) {
+                markdownContent = rewriteLinksToHtml(markdownContent);
+            }
             content = this.markdownRenderer.render(markdownContent);
         } else {
             content = fs.readFileSync(sourceFile.absolutePath, 'utf-8');

--- a/src/helpers/rewriteLinksToHtml.js
+++ b/src/helpers/rewriteLinksToHtml.js
@@ -1,0 +1,29 @@
+const url = require('url');
+const path = require('path');
+const renameMdToHtml = require('./renameMdToHtml');
+
+/**
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function rewriteLinksToHtml(text) {
+    return text.replace(/\[([^\[\]]*)\]\((.*?)\)/gm, function (link) {
+        let parts = link.match(/\[([^\[\]]*)\]\((.*?)\)/);
+
+        let title = parts[1];
+        let href = parts[2];
+
+        var parsed = url.parse(href);
+        if (!parsed.protocol) {
+            var ext = path.extname(parsed.pathname || '');
+            if (ext === '.md') {
+                parsed.pathname = renameMdToHtml(parsed.pathname);
+                href = url.format(parsed);
+            }
+        }
+        return `[${title}](${href})`;
+    });
+}
+
+module.exports = rewriteLinksToHtml;

--- a/src/marked/MarkdownRenderer.js
+++ b/src/marked/MarkdownRenderer.js
@@ -12,15 +12,12 @@ const heading = require('./heading');
 class MarkdownRenderer {
     /**
      * @param {object} options
-     * @param {boolean} options.renameMarkdownLinksToHtml allows to rename .md to .html for static rendering
      */
     constructor(options) {
         options = options || {};
-        this.renameMarkdownLinksToHtml =
-            options.renameMarkdownLinksToHtml || false;
 
         this.markedRenderer = new marked.Renderer();
-        this.markedRenderer.link = link(this.renameMarkdownLinksToHtml);
+        this.markedRenderer.link = link();
         this.markedRenderer.heading = heading;
     }
 

--- a/src/marked/link.js
+++ b/src/marked/link.js
@@ -1,26 +1,17 @@
 const url = require('url');
-const path = require('path');
-const renameMdToHtml = require('../helpers/renameMdToHtml');
 
 /**
  * marked - create custom method to render links with optional renaming from .md to .html.
  *
- * @param {boolean} renameMarkdownLinksToHtml
  * @returns {function}
  */
-function link(renameMarkdownLinksToHtml) {
+function link() {
     return function doLink(href, title, text) {
         var parsed = url.parse(href);
 
         /* convert .md links to .html for non external links */
         var target = null;
-        if (!parsed.protocol) {
-            var ext = path.extname(parsed.pathname || '');
-            if (renameMarkdownLinksToHtml && ext === '.md') {
-                parsed.pathname = renameMdToHtml(parsed.pathname);
-                href = url.format(parsed);
-            }
-        } else {
+        if (parsed.protocol != null) {
             target = '_blank';
         }
 

--- a/test/helpers/rewriteLinksToHtml.js
+++ b/test/helpers/rewriteLinksToHtml.js
@@ -1,0 +1,26 @@
+const expect = require('chai').expect;
+
+const rewriteLinksToHtml = require('../../src/helpers/rewriteLinksToHtml');
+
+describe('Test link rewrite to html', function () {
+    it('should work with relative links', function () {
+        const result = rewriteLinksToHtml('[Something](something.md)', 2);
+        const expected = '[Something](something.html)';
+        expect(result).to.equals(expected);
+    });
+
+    it('should work keep frag in relative links', function () {
+        const result = rewriteLinksToHtml('[Something](something.md#title)', 2);
+        const expected = '[Something](something.html#title)';
+        expect(result).to.equals(expected);
+    });
+
+    it('should ignore absolute url', function () {
+        const result = rewriteLinksToHtml(
+            '[Something](https://example.com/something.md)',
+            2
+        );
+        const expected = '[Something](https://example.com/something.md)';
+        expect(result).to.equals(expected);
+    });
+});

--- a/test/marked/link.js
+++ b/test/marked/link.js
@@ -9,6 +9,17 @@ describe('test link', function () {
         expect(result).to.equals(expected);
     });
 
+    it('should add _blank target for absolute', function () {
+        const result = link(false)(
+            'https://example.com',
+            null,
+            'Something text'
+        );
+        const expected =
+            '<a href="https://example.com" target="_blank">Something text</a>';
+        expect(result).to.equals(expected);
+    });
+
     it('should works for basic case with title', function () {
         const result = link(false)(
             'something.html',
@@ -20,25 +31,14 @@ describe('test link', function () {
         expect(result).to.equals(expected);
     });
 
-    it('should rename .md links to .html for relative path', function () {
+    it('should no more rename .md links to .html for relative path', function () {
         const result = link(true)(
             'something.md',
             'Something title',
             'Something text'
         );
         const expected =
-            '<a href="something.html" title="Something title">Something text</a>';
-        expect(result).to.equals(expected);
-    });
-
-    it('should rename .md links to .html for relative path keeping fragments', function () {
-        const result = link(true)(
-            'something.md#something-else',
-            null,
-            'Something text'
-        );
-        const expected =
-            '<a href="something.html#something-else">Something text</a>';
+            '<a href="something.md" title="Something title">Something text</a>';
         expect(result).to.equals(expected);
     });
 


### PR DESCRIPTION
It avoids bad links between multiple remarkjs presentations in server mode

(closes #11)
